### PR TITLE
Added *more* rules to eslintrc for module imports

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -14,5 +14,8 @@
         "brace-style": "error",
         "keyword-spacing": "error",
         "space-before-function-paren": ["error", "never"]
+    },
+    "parserOptions": {
+        "sourceType": "module"
     }
 }


### PR DESCRIPTION
Linter still freaking out about eslint settings - this should stop it. 