### PR TITLE
Feature/js sept 2018 updates

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -24,7 +24,7 @@
     },
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": "7"
+        "ecmaVersion": 2017
     },
     "globals": {
         "axios": false,

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -24,5 +24,7 @@
     },
     "parserOptions": {
         "sourceType": "module"
+        "sourceType": "module",
+        "ecmaVersion": "7"
     }
 }

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -23,8 +23,12 @@
         "space-before-function-paren": ["error", "never"]
     },
     "parserOptions": {
-        "sourceType": "module"
         "sourceType": "module",
         "ecmaVersion": "7"
+    },
+    "globals": {
+        "axios": false,
+        "jQuery": false,
+        "_" : false,
     }
 }


### PR DESCRIPTION
- Sets ECMA version to 7 to stop freakouts on async/await funcs
- Adds lodash, jQuery and axios to allowed globals to stop undefined errors